### PR TITLE
🔥 Remove vestigial temp directory code

### DIFF
--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -25,14 +25,14 @@
   "lib/turbo_tests/reporter.rb:1386902608": [
     [7, 5, 400, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 2092085575]
   ],
-  "lib/turbo_tests/runner.rb:2125673792": [
+  "lib/turbo_tests/runner.rb:3577354185": [
     [13, 5, 271, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 21989008],
     [20, 5, 1311, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 1925027850],
-    [241, 11, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
-    [260, 47, 6, "Style/GlobalStdStream: Use `$stderr` instead of `STDERR`.", 3356712163],
-    [262, 21, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
-    [271, 7, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
-    [331, 9, 6, "Style/GlobalStdStream: Use `$stdout` instead of `STDOUT`.", 3356722952]
+    [230, 11, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
+    [249, 47, 6, "Style/GlobalStdStream: Use `$stderr` instead of `STDERR`.", 3356712163],
+    [251, 21, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
+    [260, 7, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
+    [320, 9, 6, "Style/GlobalStdStream: Use `$stdout` instead of `STDOUT`.", 3356722952]
   ],
   "spec/cli_spec.rb:3990998076": [
     [1, 1, 30, "RSpec/SpecFilePathFormat: Spec path should end with `turbo_tests/cli*_spec.rb`.", 965721356],

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -105,8 +105,6 @@ module TurboTests
           **@parallel_options,
         )
 
-      setup_tmp_dir
-
       subprocess_opts = {
         record_runtime: @record_runtime,
       }
@@ -151,15 +149,6 @@ module TurboTests
         end
         @interrupt_handled = true
       end
-    end
-
-    def setup_tmp_dir
-      begin
-        FileUtils.rm_r("tmp/test-pipes")
-      rescue Errno::ENOENT
-      end
-
-      FileUtils.mkdir_p("tmp/test-pipes/")
     end
 
     def start_regular_subprocess(tests, process_id, **opts)


### PR DESCRIPTION
Changes the original intent to a removal of the tmp dir code, as it is now vestigial.

This is more accurately a duplicate of https://github.com/serpapi/turbo_tests/pull/67